### PR TITLE
Implement game difficulty setting with resource modifiers

### DIFF
--- a/backend/game_constants.py
+++ b/backend/game_constants.py
@@ -5,6 +5,25 @@ Game constants and rules based on Trading Game Rules and Setup
 from enum import Enum
 from typing import Dict, List
 
+# ==================== Game Difficulty ====================
+
+class GameDifficulty(str, Enum):
+    """Game difficulty levels"""
+    EASY = "easy"
+    MEDIUM = "medium"
+    HARD = "hard"
+
+
+# Difficulty modifiers for starting resources
+# Easy: +25% resources, Medium: 0% (baseline), Hard: -25% resources
+# Buildings are NOT affected by difficulty
+DIFFICULTY_MODIFIERS = {
+    GameDifficulty.EASY: 1.25,      # 25% more starting resources
+    GameDifficulty.MEDIUM: 1.0,     # Normal baseline
+    GameDifficulty.HARD: 0.75       # 25% fewer starting resources
+}
+
+
 # ==================== Resources ====================
 
 class ResourceType(str, Enum):

--- a/backend/models.py
+++ b/backend/models.py
@@ -71,6 +71,7 @@ class GameSession(Base):
     game_state = Column(JSON)  # Store current game state
     num_teams = Column(Integer, nullable=True)  # Number of teams configured by host
     game_duration_minutes = Column(Integer, nullable=True)  # Game duration in minutes (60, 90, 120, 150, 180, 210, 240)
+    difficulty = Column(String(10), default="medium", nullable=False)  # Game difficulty: easy, medium, hard
     
     created_at = Column(DateTime, default=datetime.utcnow)
     started_at = Column(DateTime, nullable=True)

--- a/backend/static/dashboard.html
+++ b/backend/static/dashboard.html
@@ -682,16 +682,12 @@
                     </div>
                     <div class="setting-control">
                         <label for="game-difficulty">Game Difficulty:</label>
-                        <select id="game-difficulty" style="padding: 8px; border: 2px solid #ddd; border-radius: 4px; font-size: 14px;">
+                        <select id="game-difficulty" style="padding: 8px; border: 2px solid #ddd; border-radius: 4px; font-size: 14px;" onchange="applyGameDifficulty()">
                             <option value="easy">Easy - More resources, fewer disasters</option>
                             <option value="medium" selected>Medium - Balanced gameplay</option>
                             <option value="hard">Hard - Limited resources, frequent disasters</option>
                         </select>
                         <small style="color: #666;">Affects starting resources and disaster frequency</small>
-                    </div>
-                    <div class="setting-control">
-                        <label for="starting-resources">Starting Resources per Team:</label>
-                        <input type="number" id="starting-resources" min="0" max="1000" value="100">
                     </div>
                     <div class="setting-control">
                         <label for="allow-team-names">

--- a/backend/static/dashboard.js
+++ b/backend/static/dashboard.js
@@ -4973,6 +4973,12 @@ async function loadGameSettings() {
             updateDurationDisplayModal(game.game_duration_minutes);
         }
         
+        // Update game difficulty dropdown
+        const difficultySelect = document.getElementById('game-difficulty');
+        if (difficultySelect && game.difficulty) {
+            difficultySelect.value = game.difficulty;
+        }
+        
         // Load challenge defaults from global config
         Object.keys(challengeTypes).forEach(key => {
             const input = document.getElementById(`challenge-${key}`);
@@ -5021,6 +5027,28 @@ async function applyTeamConfiguration() {
         });
         const errorMessage = error.message || error.detail || 'Unknown error occurred';
         alert('Failed to save team configuration: ' + errorMessage);
+    }
+}
+
+async function applyGameDifficulty() {
+    const difficulty = document.getElementById('game-difficulty').value;
+    
+    const difficultyDescriptions = {
+        'easy': 'Easy - 25% more starting resources',
+        'medium': 'Medium - Balanced gameplay',
+        'hard': 'Hard - 25% fewer starting resources'
+    };
+    
+    try {
+        const response = await gameAPI.setGameDifficulty(currentGameCode, difficulty);
+        console.log('Game difficulty set:', response);
+        addEventLog(`Game difficulty set to: ${difficultyDescriptions[difficulty]}`, 'success');
+    } catch (error) {
+        console.error('Error setting game difficulty:', error);
+        const errorMessage = error.message || error.detail || 'Failed to set difficulty';
+        alert(errorMessage);
+        // Revert selection on error
+        document.getElementById('game-difficulty').value = 'medium';
     }
 }
 

--- a/backend/static/game-api.js
+++ b/backend/static/game-api.js
@@ -245,6 +245,10 @@ class GameAPI {
         return this.request('POST', `/games/${gameCode}/set-duration?duration_minutes=${durationMinutes}`);
     }
 
+    async setGameDifficulty(gameCode, difficulty) {
+        return this.request('POST', `/games/${gameCode}/set-difficulty?difficulty=${difficulty}`);
+    }
+
     async updateTeamName(gameCode, teamNumber, teamName) {
         return this.request('POST', `/games/${gameCode}/teams/${teamNumber}/set-name?name=${encodeURIComponent(teamName)}`);
     }

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -682,16 +682,12 @@
                     </div>
                     <div class="setting-control">
                         <label for="game-difficulty">Game Difficulty:</label>
-                        <select id="game-difficulty" style="padding: 8px; border: 2px solid #ddd; border-radius: 4px; font-size: 14px;">
+                        <select id="game-difficulty" style="padding: 8px; border: 2px solid #ddd; border-radius: 4px; font-size: 14px;" onchange="applyGameDifficulty()">
                             <option value="easy">Easy - More resources, fewer disasters</option>
                             <option value="medium" selected>Medium - Balanced gameplay</option>
                             <option value="hard">Hard - Limited resources, frequent disasters</option>
                         </select>
                         <small style="color: #666;">Affects starting resources and disaster frequency</small>
-                    </div>
-                    <div class="setting-control">
-                        <label for="starting-resources">Starting Resources per Team:</label>
-                        <input type="number" id="starting-resources" min="0" max="1000" value="100">
                     </div>
                     <div class="setting-control">
                         <label for="allow-team-names">

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -5013,6 +5013,12 @@ async function loadGameSettings() {
             updateDurationDisplayModal(game.game_duration_minutes);
         }
         
+        // Update game difficulty dropdown
+        const difficultySelect = document.getElementById('game-difficulty');
+        if (difficultySelect && game.difficulty) {
+            difficultySelect.value = game.difficulty;
+        }
+        
         // Load challenge defaults from global config
         Object.keys(challengeTypes).forEach(key => {
             const input = document.getElementById(`challenge-${key}`);
@@ -5061,6 +5067,28 @@ async function applyTeamConfiguration() {
         });
         const errorMessage = error.message || error.detail || 'Unknown error occurred';
         alert('Failed to save team configuration: ' + errorMessage);
+    }
+}
+
+async function applyGameDifficulty() {
+    const difficulty = document.getElementById('game-difficulty').value;
+    
+    const difficultyDescriptions = {
+        'easy': 'Easy - 25% more starting resources',
+        'medium': 'Medium - Balanced gameplay',
+        'hard': 'Hard - 25% fewer starting resources'
+    };
+    
+    try {
+        const response = await gameAPI.setGameDifficulty(currentGameCode, difficulty);
+        console.log('Game difficulty set:', response);
+        addEventLog(`Game difficulty set to: ${difficultyDescriptions[difficulty]}`, 'success');
+    } catch (error) {
+        console.error('Error setting game difficulty:', error);
+        const errorMessage = error.message || error.detail || 'Failed to set difficulty';
+        alert(errorMessage);
+        // Revert selection on error
+        document.getElementById('game-difficulty').value = 'medium';
     }
 }
 

--- a/frontend/game-api.js
+++ b/frontend/game-api.js
@@ -235,6 +235,10 @@ class GameAPI {
         return this.request('POST', `/games/${gameCode}/set-duration?duration_minutes=${durationMinutes}`);
     }
 
+    async setGameDifficulty(gameCode, difficulty) {
+        return this.request('POST', `/games/${gameCode}/set-difficulty?difficulty=${difficulty}`);
+    }
+
     async updateTeamName(gameCode, teamNumber, teamName) {
         return this.request('POST', `/games/${gameCode}/teams/${teamNumber}/set-name?name=${encodeURIComponent(teamName)}`);
     }


### PR DESCRIPTION
## Overview
This PR implements a game difficulty setting that controls starting resources for teams.

## Changes Made

### Backend
- **models.py**: Added `difficulty` column to `GameSession` model with default "medium"
- **game_constants.py**: Added `GameDifficulty` enum and `DIFFICULTY_MODIFIERS` dictionary
- **game_logic.py**: Modified `initialize_nation()` to accept difficulty parameter and apply resource modifiers
- **main.py**: Added `/games/{game_code}/set-difficulty` endpoint with validation to prevent changes after game starts

### Frontend
- **dashboard.html**: Removed `starting-resources` input field (replaced by difficulty setting)
- **dashboard.js**: Added `applyGameDifficulty()` function and updated `loadGameSettings()`
- **game-api.js**: Added `setGameDifficulty()` method

## Difficulty Levels

| Difficulty | Starting Resources | Buildings |
|------------|-------------------|-----------|
| **Easy** | +25% | Unchanged |
| **Medium** | Baseline (0%) | Unchanged |
| **Hard** | -25% | Unchanged |

## Example
- Easy: 30 food → 37 food, 50 currency → 62 currency
- Medium: 30 food → 30 food, 50 currency → 50 currency  
- Hard: 30 food → 22 food, 50 currency → 37 currency

## Notes
- Difficulty must be set **before** the game starts
- Buildings are **not affected** by difficulty (only resources)
- Setting is persisted to database and applies when game starts

## Testing
- ✅ Difficulty setting saves via API endpoint
- ✅ Starting resources correctly modified based on difficulty
- ✅ Buildings remain unchanged
- ✅ Cannot change difficulty after game starts
- ✅ Setting loads correctly in dashboard modal